### PR TITLE
Add support for RelayedV2 transactions

### DIFF
--- a/multiversx_sdk_core/errors.py
+++ b/multiversx_sdk_core/errors.py
@@ -19,3 +19,13 @@ class ErrCannotSerializeArgument(Exception):
 class ErrInvalidRelayerV1BuilderArguments(Exception):
     def __init__(self) -> None:
         super().__init__("Invalid arguments for relayed v1 builder")
+
+
+class ErrInvalidRelayerV2BuilderArguments(Exception):
+    def __init__(self) -> None:
+        super().__init__("Invalid arguments for relayed v2 builder")
+
+
+class ErrInvalidGasLimitForInnerTransaction(Exception):
+    def __init__(self) -> None:
+        super().__init__("Gas limit should be 0 for the inner transaction for relayed v2")

--- a/multiversx_sdk_core/transaction_builders/__init__.py
+++ b/multiversx_sdk_core/transaction_builders/__init__.py
@@ -7,6 +7,8 @@ from multiversx_sdk_core.transaction_builders.esdt_builders import \
     ESDTIssueBuilder
 from multiversx_sdk_core.transaction_builders.relayed_v1_builder import \
     RelayedTransactionV1Builder
+from multiversx_sdk_core.transaction_builders.relayed_v2_builder import \
+    RelayedTransactionV2Builder
 from multiversx_sdk_core.transaction_builders.transaction_builder import \
     TransactionBuilder
 from multiversx_sdk_core.transaction_builders.transfers_builders import (
@@ -18,5 +20,5 @@ __all__ = [
     "DefaultTransactionBuildersConfiguration",
     "ContractCallBuilder", "ContractDeploymentBuilder", "ContractUpgradeBuilder",
     "EGLDTransferBuilder", "ESDTNFTTransferBuilder", "ESDTTransferBuilder", "MultiESDTNFTTransferBuilder",
-    "ESDTIssueBuilder", "RelayedTransactionV1Builder"
+    "ESDTIssueBuilder", "RelayedTransactionV1Builder", "RelayedTransactionV2Builder"
 ]

--- a/multiversx_sdk_core/transaction_builders/relayed_builders.py
+++ b/multiversx_sdk_core/transaction_builders/relayed_builders.py
@@ -1,3 +1,0 @@
-class RelayedTransactionV2Builder:
-    def __init__(self) -> None:
-        raise NotImplementedError()

--- a/multiversx_sdk_core/transaction_builders/relayed_v2_builder.py
+++ b/multiversx_sdk_core/transaction_builders/relayed_v2_builder.py
@@ -43,6 +43,7 @@ class RelayedTransactionV2Builder:
             or not self.network_config
             or not self.relayer_address
             or not self.inner_transaction.signature
+            or not self.inner_transaction_gas_limit
         ):
             raise ErrInvalidRelayerV2BuilderArguments()
 
@@ -63,7 +64,7 @@ class RelayedTransactionV2Builder:
             sender=self.relayer_address,
             receiver=self.inner_transaction.sender,
             value=0,
-            gas_limit=self.inner_transaction.gas_limit + self.network_config.min_gas_limit + self.network_config.gas_per_data_byte * payload.length(),
+            gas_limit=self.inner_transaction_gas_limit + self.network_config.min_gas_limit + self.network_config.gas_per_data_byte * payload.length(),
             chain_id=self.network_config.chain_id,
             data=payload
         )

--- a/multiversx_sdk_core/transaction_builders/relayed_v2_builder.py
+++ b/multiversx_sdk_core/transaction_builders/relayed_v2_builder.py
@@ -1,0 +1,74 @@
+from typing import Any, List, Optional
+
+from multiversx_sdk_core.errors import (ErrInvalidGasLimitForInnerTransaction,
+                                        ErrInvalidRelayerV2BuilderArguments)
+from multiversx_sdk_core.interfaces import (IAddress, IGasLimit,
+                                            INetworkConfig, INonce)
+from multiversx_sdk_core.serializer import args_to_string
+from multiversx_sdk_core.transaction import Transaction
+from multiversx_sdk_core.transaction_payload import TransactionPayload
+
+
+class RelayedTransactionV2Builder:
+    def __init__(
+            self, inner_transaction: Optional[Transaction] = None,
+            inner_transaction_gas_limit: Optional[IGasLimit] = None,
+            relayer_address: Optional[IAddress] = None,
+            relayer_nonce: Optional[INonce] = None,
+            network_config: Optional[INetworkConfig] = None) -> None:
+        self.inner_transaction = inner_transaction
+        self.inner_transaction_gas_limit = inner_transaction_gas_limit
+        self.relayer_address = relayer_address
+        self.relayer_nonce = relayer_nonce
+        self.network_config = network_config
+
+    def set_inner_transaction(self, transaction: Transaction) -> None:
+        self.inner_transaction = transaction
+
+    def set_inner_transaction_gas_limit(self, gas_limit: IGasLimit) -> None:
+        self.inner_transaction_gas_limit = gas_limit
+
+    def set_network_config(self, network_config: INetworkConfig) -> None:
+        self.network_config = network_config
+
+    def set_relayer_address(self, relayer_address: IAddress) -> None:
+        self.relayer_address = relayer_address
+
+    def set_relayer_nonce(self, relayer_nonce: INonce) -> None:
+        self.relayer_nonce = relayer_nonce
+
+    def build(self) -> Transaction:
+        if (
+            not self.inner_transaction
+            or not self.network_config
+            or not self.relayer_address
+            or not self.inner_transaction.signature
+        ):
+            raise ErrInvalidRelayerV2BuilderArguments()
+
+        if self.inner_transaction.gas_limit:
+            raise ErrInvalidGasLimitForInnerTransaction()
+
+        arguments: List[Any] = [
+            self.inner_transaction.receiver,
+            self.inner_transaction.nonce,
+            self.inner_transaction.data.data,
+            self.inner_transaction.signature
+        ]
+
+        data = f"relayedTxV2@{args_to_string(arguments)}"
+        payload = TransactionPayload.from_str(data)
+
+        relayed_transaction = Transaction(
+            sender=self.relayer_address,
+            receiver=self.inner_transaction.sender,
+            value=0,
+            gas_limit=self.inner_transaction.gas_limit + self.network_config.min_gas_limit + self.network_config.gas_per_data_byte * payload.length(),
+            chain_id=self.network_config.chain_id,
+            data=payload
+        )
+
+        if self.relayer_nonce:
+            relayed_transaction.nonce = self.relayer_nonce
+
+        return relayed_transaction

--- a/multiversx_sdk_core/transaction_builders/relayed_v2_builder_test.py
+++ b/multiversx_sdk_core/transaction_builders/relayed_v2_builder_test.py
@@ -1,0 +1,86 @@
+import pytest
+
+from multiversx_sdk_core.address import Address
+from multiversx_sdk_core.errors import (ErrInvalidGasLimitForInnerTransaction,
+                                        ErrInvalidRelayerV2BuilderArguments)
+from multiversx_sdk_core.testutils.wallets import load_wallets
+from multiversx_sdk_core.transaction import Transaction
+from multiversx_sdk_core.transaction_builders.relayed_v2_builder import \
+    RelayedTransactionV2Builder
+from multiversx_sdk_core.transaction_payload import TransactionPayload
+
+
+class NetworkConfig:
+    def __init__(self) -> None:
+        self.min_gas_limit = 50_000
+        self.gas_per_data_byte = 1_500
+        self.gas_price_modifier = 0.01
+        self.chain_id = "T"
+
+
+class TestRelayedV2Builder:
+    wallets = load_wallets()
+    alice = wallets["alice"]
+    bob = wallets["bob"]
+
+    def test_without_arguments(self):
+        relayed_builder = RelayedTransactionV2Builder()
+
+        with pytest.raises(ErrInvalidRelayerV2BuilderArguments):
+            relayed_builder.build()
+
+    def test_with_inner_tx_gas_limit(self):
+        builder = RelayedTransactionV2Builder()
+        network_config = NetworkConfig()
+
+        inner_tx = Transaction(
+            chain_id=network_config.chain_id,
+            sender=Address.from_bech32(self.alice.label),
+            receiver=Address.from_bech32("erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u"),
+            gas_limit=10,
+            nonce=15,
+            data=TransactionPayload.from_str("getContractConfig")
+        )
+        # version is set to 1 to match the test in sdk-js-core
+        inner_tx.version = 1
+        inner_tx.signature = self.alice.secret_key.sign(inner_tx.serialize_for_signing())
+
+        builder.set_network_config(network_config)
+        builder.set_inner_transaction_gas_limit(10)
+        builder.set_inner_transaction(inner_tx)
+        builder.set_relayer_address(Address.from_bech32(self.alice.label))
+
+        with pytest.raises(ErrInvalidGasLimitForInnerTransaction):
+            builder.build()
+
+    def test_compute_relayed_v2_transaction(self):
+        network_config = NetworkConfig()
+
+        inner_tx = Transaction(
+            chain_id=network_config.chain_id,
+            sender=Address.from_bech32(self.bob.label),
+            receiver=Address.from_bech32("erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u"),
+            gas_limit=0,
+            nonce=15,
+            data=TransactionPayload.from_str("getContractConfig")
+        )
+        # version is set to 1 to match the test in sdk-js-core
+        inner_tx.version = 1
+        inner_tx.signature = self.bob.secret_key.sign(inner_tx.serialize_for_signing())
+
+        builder = RelayedTransactionV2Builder()
+        builder.set_inner_transaction(inner_tx)
+        builder.set_inner_transaction_gas_limit(60_000_000)
+        builder.set_relayer_nonce(37)
+        builder.set_network_config(network_config)
+        builder.set_relayer_address(Address.from_bech32(self.alice.label))
+
+        relayed_tx = builder.build()
+        # version is set to 1 to match the test in sdk-js-core
+        relayed_tx.version = 1
+
+        relayed_tx.sender = Address.from_bech32(self.alice.label)
+        relayed_tx.signature = self.alice.secret_key.sign(relayed_tx.serialize_for_signing())
+
+        assert relayed_tx.nonce == 37
+        assert str(relayed_tx.data) == "relayedTxV2@000000000000000000010000000000000000000000000000000000000002ffff@0f@676574436f6e7472616374436f6e666967@b6c5262d9837853e2201de357c1cc4c9803988a42d7049d26b7785dd0ac2bd4c6a8804b6fd9cf845fe2c2a622774b1a2dbd0a417c9a0bc3f0563a85bd15e710a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "multiversx-sdk-core"
-version = "0.4.4"
+version = "0.4.5"
 authors = [
   { name="MultiversX" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "multiversx-sdk-core"
-version = "0.4.5"
+version = "0.5.0"
 authors = [
   { name="MultiversX" },
 ]


### PR DESCRIPTION
Added support for RelayedV2 transactions.
Also added unit tests. The tests are the ones from mx-sdk-js-core and can be found [here](https://github.com/multiversx/mx-sdk-js-core/blob/main/src/relayedTransactionV2Builder.spec.ts)