### PR TITLE
Transfer and execute

### DIFF
--- a/multiversx_sdk_core/proto/transaction_serializer.py
+++ b/multiversx_sdk_core/proto/transaction_serializer.py
@@ -57,7 +57,7 @@ class ProtoSerializer:
 
         if self._is_guarded_transaction(transaction):
             guardian_address = transaction.guardian
-            proto_transaction.GuardAddr = self.address_converter.bech32_to_pubkey(guardian_address)
+            proto_transaction.GuardAddr = bytes(self.address_converter.bech32_to_pubkey(guardian_address))
             proto_transaction.GuardSignature = transaction.guardian_signature
 
         encoded_tx: bytes = proto_transaction.SerializeToString()

--- a/multiversx_sdk_core/transaction_factories/smart_contract_transaction_factory_test.py
+++ b/multiversx_sdk_core/transaction_factories/smart_contract_transaction_factory_test.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from multiversx_sdk_core.address import Address
 from multiversx_sdk_core.constants import CONTRACT_DEPLOY_ADDRESS
+from multiversx_sdk_core.tokens import Token, TokenTransfer
 from multiversx_sdk_core.transaction_factories.smart_contract_transactions_factory import \
     SmartContractTransactionsFactory
 from multiversx_sdk_core.transaction_factories.transactions_factory_config import \
@@ -31,26 +32,148 @@ class TestSmartContractTransactionsFactory:
         assert intent.gas_limit == gas_limit
         assert intent.amount == 0
 
-    def test_create_transaction_intent_for_execute(self):
+    def test_create_transaction_for_execute_and_tranfer_native_token(self):
         sender = Address.from_bech32("erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th")
         contract = Address.from_bech32("erd1qqqqqqqqqqqqqpgqhy6nl6zq07rnzry8uyh6rtyq0uzgtk3e69fqgtz9l4")
         function = "add"
         gas_limit = 6000000
         args = [7]
+        egld_amount = 1000000000000000000
 
-        intent = self.factory.create_transaction_intent_for_execute(
+        intent = self.factory.create_transaction_for_execute(
             sender=sender,
-            contract_address=contract,
+            contract=contract,
             function=function,
             gas_limit=gas_limit,
-            arguments=args
+            arguments=args,
+            native_transfer_amount=egld_amount
         )
 
         assert intent.sender == "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"
-        assert intent.receiver == contract.bech32()
+        assert intent.receiver == "erd1qqqqqqqqqqqqqpgqhy6nl6zq07rnzry8uyh6rtyq0uzgtk3e69fqgtz9l4"
         assert intent.gas_limit == gas_limit
         assert intent.data
         assert intent.data.decode() == "add@07"
+        assert intent.amount == 1000000000000000000
+
+    def test_create_transaction_for_execute_and_send_single_esdt(self):
+        sender = Address.from_bech32("erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th")
+        contract = Address.from_bech32("erd1qqqqqqqqqqqqqpgqhy6nl6zq07rnzry8uyh6rtyq0uzgtk3e69fqgtz9l4")
+        function = "dummy"
+        gas_limit = 6000000
+        args = [7]
+        token = Token("FOO-6ce17b", 0)
+        transfer = TokenTransfer(token, 10)
+
+        hex_foo = "464f4f2d366365313762"
+        hex_dummy_function = "64756d6d79"
+
+        intent = self.factory.create_transaction_for_execute(
+            sender=sender,
+            contract=contract,
+            function=function,
+            gas_limit=gas_limit,
+            arguments=args,
+            token_transfers=[transfer]
+        )
+
+        assert intent.sender == "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"
+        assert intent.receiver == "erd1qqqqqqqqqqqqqpgqhy6nl6zq07rnzry8uyh6rtyq0uzgtk3e69fqgtz9l4"
+        assert intent.gas_limit == gas_limit
+        assert intent.data
+        assert intent.data.decode() == f"ESDTTransfer@{hex_foo}@0a@{hex_dummy_function}@07"
+        assert intent.amount == 0
+
+    def test_create_transaction_for_execute_and_send_multiple_esdts(self):
+        sender = Address.from_bech32("erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th")
+        contract = Address.from_bech32("erd1qqqqqqqqqqqqqpgqak8zt22wl2ph4tswtyc39namqx6ysa2sd8ss4xmlj3")
+        function = "dummy"
+        gas_limit = 6000000
+        args = [7]
+
+        foo_token = Token("FOO-6ce17b", 0)
+        foo_transfer = TokenTransfer(foo_token, 10)
+
+        bar_token = Token("BAR-5bc08f", 0)
+        bar_transfer = TokenTransfer(bar_token, 3140)
+
+        hex_foo = "464f4f2d366365313762"
+        hex_bar = "4241522d356263303866"
+        hex_dummy_function = "64756d6d79"
+
+        intent = self.factory.create_transaction_for_execute(
+            sender=sender,
+            contract=contract,
+            function=function,
+            gas_limit=gas_limit,
+            arguments=args,
+            token_transfers=[foo_transfer, bar_transfer]
+        )
+
+        assert intent.sender == "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"
+        assert intent.receiver == "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"
+        assert intent.gas_limit == gas_limit
+        assert intent.data
+        assert intent.data.decode() == f"MultiESDTNFTTransfer@{contract.hex()}@02@{hex_foo}@@0a@{hex_bar}@@0c44@{hex_dummy_function}@07"
+        assert intent.amount == 0
+
+    def test_create_transaction_for_execute_and_send_single_nft(self):
+        sender = Address.from_bech32("erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th")
+        contract = Address.from_bech32("erd1qqqqqqqqqqqqqpgqhy6nl6zq07rnzry8uyh6rtyq0uzgtk3e69fqgtz9l4")
+        function = "dummy"
+        gas_limit = 6000000
+        args = [7]
+        token = Token("MOS-b9b4b2", 1)
+        transfer = TokenTransfer(token, 1)
+
+        hex_token = "4d4f532d623962346232"
+        hex_dummy_function = "64756d6d79"
+
+        intent = self.factory.create_transaction_for_execute(
+            sender=sender,
+            contract=contract,
+            function=function,
+            gas_limit=gas_limit,
+            arguments=args,
+            token_transfers=[transfer]
+        )
+
+        assert intent.sender == "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"
+        assert intent.receiver == "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"
+        assert intent.gas_limit == gas_limit
+        assert intent.data
+        assert intent.data.decode() == f"ESDTNFTTransfer@{hex_token}@01@01@{contract.hex()}@{hex_dummy_function}@07"
+        assert intent.amount == 0
+
+    def test_create_transaction_for_execute_and_send_multiple_nfts(self):
+        sender = Address.from_bech32("erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th")
+        contract = Address.from_bech32("erd1qqqqqqqqqqqqqpgqhy6nl6zq07rnzry8uyh6rtyq0uzgtk3e69fqgtz9l4")
+        function = "dummy"
+        gas_limit = 6000000
+        args = [7]
+
+        first_token = Token("MOS-b9b4b2", 1)
+        first_transfer = TokenTransfer(first_token, 1)
+        second_token = Token("MOS-b9b4b2", 42)
+        second_transfer = TokenTransfer(second_token, 1)
+
+        hex_token = "4d4f532d623962346232"
+        hex_dummy_function = "64756d6d79"
+
+        intent = self.factory.create_transaction_for_execute(
+            sender=sender,
+            contract=contract,
+            function=function,
+            gas_limit=gas_limit,
+            arguments=args,
+            token_transfers=[first_transfer, second_transfer]
+        )
+
+        assert intent.sender == "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"
+        assert intent.receiver == "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"
+        assert intent.gas_limit == gas_limit
+        assert intent.data
+        assert intent.data.decode() == f"MultiESDTNFTTransfer@{contract.hex()}@02@{hex_token}@01@01@{hex_token}@2a@01@{hex_dummy_function}@07"
         assert intent.amount == 0
 
     def test_create_transaction_for_upgrade(self):

--- a/multiversx_sdk_core/transaction_factories/smart_contract_transaction_factory_test.py
+++ b/multiversx_sdk_core/transaction_factories/smart_contract_transaction_factory_test.py
@@ -19,18 +19,18 @@ class TestSmartContractTransactionsFactory:
         gas_limit = 6000000
         args = [0]
 
-        intent = self.factory.create_transaction_for_deploy(
+        transaction = self.factory.create_transaction_for_deploy(
             sender=sender,
             bytecode=contract,
             gas_limit=gas_limit,
             arguments=args
         )
 
-        assert intent.sender == "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"
-        assert intent.receiver == CONTRACT_DEPLOY_ADDRESS
-        assert intent.data
-        assert intent.gas_limit == gas_limit
-        assert intent.amount == 0
+        assert transaction.sender == "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"
+        assert transaction.receiver == CONTRACT_DEPLOY_ADDRESS
+        assert transaction.data
+        assert transaction.gas_limit == gas_limit
+        assert transaction.amount == 0
 
     def test_create_transaction_for_execute_and_tranfer_native_token(self):
         sender = Address.from_bech32("erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th")
@@ -40,7 +40,7 @@ class TestSmartContractTransactionsFactory:
         args = [7]
         egld_amount = 1000000000000000000
 
-        intent = self.factory.create_transaction_for_execute(
+        transaction = self.factory.create_transaction_for_execute(
             sender=sender,
             contract=contract,
             function=function,
@@ -49,12 +49,12 @@ class TestSmartContractTransactionsFactory:
             native_transfer_amount=egld_amount
         )
 
-        assert intent.sender == "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"
-        assert intent.receiver == "erd1qqqqqqqqqqqqqpgqhy6nl6zq07rnzry8uyh6rtyq0uzgtk3e69fqgtz9l4"
-        assert intent.gas_limit == gas_limit
-        assert intent.data
-        assert intent.data.decode() == "add@07"
-        assert intent.amount == 1000000000000000000
+        assert transaction.sender == "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"
+        assert transaction.receiver == "erd1qqqqqqqqqqqqqpgqhy6nl6zq07rnzry8uyh6rtyq0uzgtk3e69fqgtz9l4"
+        assert transaction.gas_limit == gas_limit
+        assert transaction.data
+        assert transaction.data.decode() == "add@07"
+        assert transaction.amount == 1000000000000000000
 
     def test_create_transaction_for_execute_and_send_single_esdt(self):
         sender = Address.from_bech32("erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th")
@@ -68,7 +68,7 @@ class TestSmartContractTransactionsFactory:
         hex_foo = "464f4f2d366365313762"
         hex_dummy_function = "64756d6d79"
 
-        intent = self.factory.create_transaction_for_execute(
+        transaction = self.factory.create_transaction_for_execute(
             sender=sender,
             contract=contract,
             function=function,
@@ -77,12 +77,12 @@ class TestSmartContractTransactionsFactory:
             token_transfers=[transfer]
         )
 
-        assert intent.sender == "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"
-        assert intent.receiver == "erd1qqqqqqqqqqqqqpgqhy6nl6zq07rnzry8uyh6rtyq0uzgtk3e69fqgtz9l4"
-        assert intent.gas_limit == gas_limit
-        assert intent.data
-        assert intent.data.decode() == f"ESDTTransfer@{hex_foo}@0a@{hex_dummy_function}@07"
-        assert intent.amount == 0
+        assert transaction.sender == "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"
+        assert transaction.receiver == "erd1qqqqqqqqqqqqqpgqhy6nl6zq07rnzry8uyh6rtyq0uzgtk3e69fqgtz9l4"
+        assert transaction.gas_limit == gas_limit
+        assert transaction.data
+        assert transaction.data.decode() == f"ESDTTransfer@{hex_foo}@0a@{hex_dummy_function}@07"
+        assert transaction.amount == 0
 
     def test_create_transaction_for_execute_and_send_multiple_esdts(self):
         sender = Address.from_bech32("erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th")
@@ -101,7 +101,7 @@ class TestSmartContractTransactionsFactory:
         hex_bar = "4241522d356263303866"
         hex_dummy_function = "64756d6d79"
 
-        intent = self.factory.create_transaction_for_execute(
+        transaction = self.factory.create_transaction_for_execute(
             sender=sender,
             contract=contract,
             function=function,
@@ -110,12 +110,12 @@ class TestSmartContractTransactionsFactory:
             token_transfers=[foo_transfer, bar_transfer]
         )
 
-        assert intent.sender == "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"
-        assert intent.receiver == "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"
-        assert intent.gas_limit == gas_limit
-        assert intent.data
-        assert intent.data.decode() == f"MultiESDTNFTTransfer@{contract.hex()}@02@{hex_foo}@@0a@{hex_bar}@@0c44@{hex_dummy_function}@07"
-        assert intent.amount == 0
+        assert transaction.sender == "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"
+        assert transaction.receiver == "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"
+        assert transaction.gas_limit == gas_limit
+        assert transaction.data
+        assert transaction.data.decode() == f"MultiESDTNFTTransfer@{contract.hex()}@02@{hex_foo}@@0a@{hex_bar}@@0c44@{hex_dummy_function}@07"
+        assert transaction.amount == 0
 
     def test_create_transaction_for_execute_and_send_single_nft(self):
         sender = Address.from_bech32("erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th")
@@ -129,7 +129,7 @@ class TestSmartContractTransactionsFactory:
         hex_token = "4d4f532d623962346232"
         hex_dummy_function = "64756d6d79"
 
-        intent = self.factory.create_transaction_for_execute(
+        transaction = self.factory.create_transaction_for_execute(
             sender=sender,
             contract=contract,
             function=function,
@@ -138,12 +138,12 @@ class TestSmartContractTransactionsFactory:
             token_transfers=[transfer]
         )
 
-        assert intent.sender == "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"
-        assert intent.receiver == "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"
-        assert intent.gas_limit == gas_limit
-        assert intent.data
-        assert intent.data.decode() == f"ESDTNFTTransfer@{hex_token}@01@01@{contract.hex()}@{hex_dummy_function}@07"
-        assert intent.amount == 0
+        assert transaction.sender == "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"
+        assert transaction.receiver == "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"
+        assert transaction.gas_limit == gas_limit
+        assert transaction.data
+        assert transaction.data.decode() == f"ESDTNFTTransfer@{hex_token}@01@01@{contract.hex()}@{hex_dummy_function}@07"
+        assert transaction.amount == 0
 
     def test_create_transaction_for_execute_and_send_multiple_nfts(self):
         sender = Address.from_bech32("erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th")
@@ -160,7 +160,7 @@ class TestSmartContractTransactionsFactory:
         hex_token = "4d4f532d623962346232"
         hex_dummy_function = "64756d6d79"
 
-        intent = self.factory.create_transaction_for_execute(
+        transaction = self.factory.create_transaction_for_execute(
             sender=sender,
             contract=contract,
             function=function,
@@ -169,12 +169,12 @@ class TestSmartContractTransactionsFactory:
             token_transfers=[first_transfer, second_transfer]
         )
 
-        assert intent.sender == "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"
-        assert intent.receiver == "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"
-        assert intent.gas_limit == gas_limit
-        assert intent.data
-        assert intent.data.decode() == f"MultiESDTNFTTransfer@{contract.hex()}@02@{hex_token}@01@01@{hex_token}@2a@01@{hex_dummy_function}@07"
-        assert intent.amount == 0
+        assert transaction.sender == "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"
+        assert transaction.receiver == "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"
+        assert transaction.gas_limit == gas_limit
+        assert transaction.data
+        assert transaction.data.decode() == f"MultiESDTNFTTransfer@{contract.hex()}@02@{hex_token}@01@01@{hex_token}@2a@01@{hex_dummy_function}@07"
+        assert transaction.amount == 0
 
     def test_create_transaction_for_upgrade(self):
         sender = Address.from_bech32("erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th")
@@ -183,7 +183,7 @@ class TestSmartContractTransactionsFactory:
         gas_limit = 6000000
         args = [0]
 
-        intent = self.factory.create_transaction_for_upgrade(
+        transaction = self.factory.create_transaction_for_upgrade(
             sender=sender,
             contract=contract_address,
             bytecode=contract,
@@ -191,9 +191,9 @@ class TestSmartContractTransactionsFactory:
             arguments=args
         )
 
-        assert intent.sender == "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"
-        assert intent.receiver == "erd1qqqqqqqqqqqqqpgqhy6nl6zq07rnzry8uyh6rtyq0uzgtk3e69fqgtz9l4"
-        assert intent.data
-        assert intent.data.decode().startswith("upgradeContract@")
-        assert intent.gas_limit == gas_limit
-        assert intent.amount == 0
+        assert transaction.sender == "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"
+        assert transaction.receiver == "erd1qqqqqqqqqqqqqpgqhy6nl6zq07rnzry8uyh6rtyq0uzgtk3e69fqgtz9l4"
+        assert transaction.data
+        assert transaction.data.decode().startswith("upgradeContract@")
+        assert transaction.gas_limit == gas_limit
+        assert transaction.amount == 0

--- a/multiversx_sdk_core/transaction_factories/smart_contract_transactions_factory.py
+++ b/multiversx_sdk_core/transaction_factories/smart_contract_transactions_factory.py
@@ -6,8 +6,10 @@ from multiversx_sdk_core.address import Address
 from multiversx_sdk_core.code_metadata import CodeMetadata
 from multiversx_sdk_core.constants import (CONTRACT_DEPLOY_ADDRESS,
                                            VM_TYPE_WASM_VM)
+from multiversx_sdk_core.errors import BadUsageError
 from multiversx_sdk_core.interfaces import IAddress
 from multiversx_sdk_core.serializer import arg_to_string, args_to_strings
+from multiversx_sdk_core.tokens import TokenComputer, TokenTransfer
 from multiversx_sdk_core.transaction_factories.transaction_builder import \
     TransactionBuilder
 
@@ -57,24 +59,83 @@ class SmartContractTransactionsFactory:
 
         return transaction
 
-    def create_transaction_intent_for_execute(self,
-                                              sender: IAddress,
-                                              contract_address: IAddress,
-                                              function: str,
-                                              gas_limit: int,
-                                              arguments: List[Any] = []) -> Transaction:
-        parts = [function] + args_to_strings(arguments)
+    def create_transaction_for_execute(self,
+                                       sender: IAddress,
+                                       contract: IAddress,
+                                       function: str,
+                                       gas_limit: int,
+                                       arguments: List[Any] = [],
+                                       native_transfer_amount: int = 0,
+                                       token_transfers: List[TokenTransfer] = []) -> Transaction:
+        number_of_tokens = len(token_transfers)
 
-        intent = TransactionBuilder(
+        if native_transfer_amount and number_of_tokens:
+            raise BadUsageError("Can't send both native token and ESDT/NFT tokens")
+
+        token_computer = TokenComputer()
+        transfer_args: List[str] = []
+
+        if len(token_transfers) == 1:
+            transfer = token_transfers[0]
+
+            if token_computer.is_fungible(transfer.token):
+                transfer_args = self._build_args_for_esdt_transfer(transfer)
+                transfer_args.append(arg_to_string(function))
+                transfer_args.extend(args_to_strings(arguments))
+            else:
+                transfer_args = self._build_args_for_single_esdt_nft_transfer(transfer)
+                transfer_args.append(contract.hex())
+                contract = sender
+                transfer_args.append(arg_to_string(function))
+                transfer_args.extend(args_to_strings(arguments))
+        elif len(token_transfers) > 1:
+            transfer_args = self._build_args_for_multi_esdt_nft_transfer(contract.hex(), token_transfers)
+            contract = sender
+            transfer_args.append(arg_to_string(function))
+            transfer_args.extend(args_to_strings(arguments))
+        else:
+            transfer_args.append(function)
+            transfer_args.extend(args_to_strings(arguments))
+
+        transaction = TransactionBuilder(
             config=self.config,
             sender=sender,
-            receiver=contract_address,
-            data_parts=parts,
+            receiver=contract,
+            data_parts=transfer_args,
             gas_limit=gas_limit,
-            add_data_movement_gas=False
+            add_data_movement_gas=False,
+            amount=native_transfer_amount
         ).build()
 
-        return intent
+        return transaction
+
+    def _build_args_for_esdt_transfer(self, transfer: TokenTransfer) -> List[str]:
+        args: List[str] = ["ESDTTransfer"]
+        args.extend(args_to_strings([transfer.token.identifier, transfer.amount]))
+        return args
+
+    def _build_args_for_single_esdt_nft_transfer(self, transfer: TokenTransfer) -> List[str]:
+        args: List[str] = ["ESDTNFTTransfer"]
+        token = transfer.token
+        identifier = self._ensure_identifier_has_correct_structure(token.identifier)
+        args.extend(args_to_strings([identifier, token.nonce, transfer.amount]))
+        return args
+
+    def _build_args_for_multi_esdt_nft_transfer(self, contract: str, transfers: List[TokenTransfer]) -> List[str]:
+        args: List[str] = ["MultiESDTNFTTransfer", contract, arg_to_string(len(transfers))]
+
+        for transfer in transfers:
+            identifier = self._ensure_identifier_has_correct_structure(transfer.token.identifier)
+            args.extend(args_to_strings([identifier, transfer.token.nonce, transfer.amount]))
+
+        return args
+
+    def _ensure_identifier_has_correct_structure(self, identifier: str) -> str:
+        if identifier.count("-") == 1:
+            return identifier
+
+        token_computer = TokenComputer()
+        return token_computer.extract_identifier_from_extended_identifier(identifier)
 
     def create_transaction_for_upgrade(self,
                                        sender: IAddress,


### PR DESCRIPTION
Modified the `create_transaction_for_execute()` method according to the sdk-specs, so you can both transfer tokens and execute a smart contract function.
Also added unit tests.