### PR TITLE
Add new delegation operations

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,8 +8,6 @@
   "[python]": {
     "editor.defaultFormatter": "ms-python.autopep8"
   },
-  "python.formatting.provider": "autopep8",
-  "python.formatting.autopep8Path": "autopep8",
   "editor.defaultFormatter": "ms-python.autopep8",
   "editor.codeActionsOnSave": {
     "source.organizeImports": true

--- a/multiversx_sdk_core/transaction_factories/delegation_transactions_factory.py
+++ b/multiversx_sdk_core/transaction_factories/delegation_transactions_factory.py
@@ -323,3 +323,70 @@ class DelegationTransactionsFactory:
         ).build()
 
         return transaction
+
+    def create_transaction_for_delegating(self,
+                                          sender: IAddress,
+                                          delegation_contract: IAddress,
+                                          amount: int) -> Transaction:
+        return TransactionBuilder(
+            config=self.config,
+            sender=sender,
+            receiver=delegation_contract,
+            data_parts=["delegate"],
+            gas_limit=12000000,
+            add_data_movement_gas=False,
+            amount=amount
+        ).build()
+
+    def create_transaction_for_claiming_rewards(self,
+                                                sender: IAddress,
+                                                delegation_contract: IAddress) -> Transaction:
+        return TransactionBuilder(
+            config=self.config,
+            sender=sender,
+            receiver=delegation_contract,
+            data_parts=["claimRewards"],
+            gas_limit=6000000,
+            add_data_movement_gas=False,
+            amount=0
+        ).build()
+
+    def create_transaction_for_redelegating_rewards(self,
+                                                    sender: IAddress,
+                                                    delegation_contract: IAddress) -> Transaction:
+        return TransactionBuilder(
+            config=self.config,
+            sender=sender,
+            receiver=delegation_contract,
+            data_parts=["reDelegateRewards"],
+            gas_limit=12000000,
+            add_data_movement_gas=False,
+            amount=0
+        ).build()
+
+    def create_transaction_for_undelegating(self,
+                                            sender: IAddress,
+                                            delegation_contract: IAddress,
+                                            amount: int) -> Transaction:
+        return TransactionBuilder(
+            config=self.config,
+            sender=sender,
+            receiver=delegation_contract,
+            data_parts=["unDelegate", arg_to_string(amount)],
+            gas_limit=12000000,
+            add_data_movement_gas=False,
+            amount=0
+        ).build()
+
+    def create_transaction_for_withdrawing(self,
+                                           sender: IAddress,
+                                           delegation_contract: IAddress) -> Transaction:
+        return TransactionBuilder(
+            config=self.config,
+            sender=sender,
+            receiver=delegation_contract,
+            data_parts=["withdraw"],
+            gas_limit=12000000,
+            add_data_movement_gas=False,
+            amount=0
+        ).build()

--- a/multiversx_sdk_core/transaction_factories/delegation_transactions_factory_test.py
+++ b/multiversx_sdk_core/transaction_factories/delegation_transactions_factory_test.py
@@ -252,3 +252,85 @@ class TestDelegationTransactionFactory:
         assert transaction.data
         assert transaction.data.decode() == "setMetaData@6e616d65@77656273697465@6964656e746966696572"
         assert transaction.amount == 0
+
+    def test_create_transaction_for_delegating(self):
+        sender = Address.new_from_bech32("erd18s6a06ktr2v6fgxv4ffhauxvptssnaqlds45qgsrucemlwc8rawq553rt2")
+        delegation_contract = Address.new_from_bech32("erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqtllllls002zgc")
+
+        transaction = self.factory.create_transaction_for_delegating(
+            sender=sender,
+            delegation_contract=delegation_contract,
+            amount=1000000000000000000
+        )
+
+        assert transaction.sender == "erd18s6a06ktr2v6fgxv4ffhauxvptssnaqlds45qgsrucemlwc8rawq553rt2"
+        assert transaction.receiver == "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqtllllls002zgc"
+        assert transaction.data
+        assert transaction.data.decode() == "delegate"
+        assert transaction.amount == 1000000000000000000
+        assert transaction.gas_limit == 12000000
+
+    def test_create_transaction_for_claiming_rewards(self):
+        sender = Address.new_from_bech32("erd18s6a06ktr2v6fgxv4ffhauxvptssnaqlds45qgsrucemlwc8rawq553rt2")
+        delegation_contract = Address.new_from_bech32("erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqtllllls002zgc")
+
+        transaction = self.factory.create_transaction_for_claiming_rewards(
+            sender=sender,
+            delegation_contract=delegation_contract
+        )
+
+        assert transaction.sender == "erd18s6a06ktr2v6fgxv4ffhauxvptssnaqlds45qgsrucemlwc8rawq553rt2"
+        assert transaction.receiver == "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqtllllls002zgc"
+        assert transaction.data
+        assert transaction.data.decode() == "claimRewards"
+        assert transaction.amount == 0
+        assert transaction.gas_limit == 6000000
+
+    def test_create_transaction_for_redelegating_rewards(self):
+        sender = Address.new_from_bech32("erd18s6a06ktr2v6fgxv4ffhauxvptssnaqlds45qgsrucemlwc8rawq553rt2")
+        delegation_contract = Address.new_from_bech32("erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqtllllls002zgc")
+
+        transaction = self.factory.create_transaction_for_redelegating_rewards(
+            sender=sender,
+            delegation_contract=delegation_contract
+        )
+
+        assert transaction.sender == "erd18s6a06ktr2v6fgxv4ffhauxvptssnaqlds45qgsrucemlwc8rawq553rt2"
+        assert transaction.receiver == "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqtllllls002zgc"
+        assert transaction.data
+        assert transaction.data.decode() == "reDelegateRewards"
+        assert transaction.amount == 0
+        assert transaction.gas_limit == 12000000
+
+    def test_create_transaction_for_undelegating(self):
+        sender = Address.new_from_bech32("erd18s6a06ktr2v6fgxv4ffhauxvptssnaqlds45qgsrucemlwc8rawq553rt2")
+        delegation_contract = Address.new_from_bech32("erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqtllllls002zgc")
+
+        transaction = self.factory.create_transaction_for_undelegating(
+            sender=sender,
+            delegation_contract=delegation_contract,
+            amount=1000000000000000000
+        )
+
+        assert transaction.sender == "erd18s6a06ktr2v6fgxv4ffhauxvptssnaqlds45qgsrucemlwc8rawq553rt2"
+        assert transaction.receiver == "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqtllllls002zgc"
+        assert transaction.data
+        assert transaction.data.decode() == "unDelegate@0de0b6b3a7640000"
+        assert transaction.amount == 0
+        assert transaction.gas_limit == 12000000
+
+    def test_create_transaction_for_withdrawing(self):
+        sender = Address.new_from_bech32("erd18s6a06ktr2v6fgxv4ffhauxvptssnaqlds45qgsrucemlwc8rawq553rt2")
+        delegation_contract = Address.new_from_bech32("erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqtllllls002zgc")
+
+        transaction = self.factory.create_transaction_for_withdrawing(
+            sender=sender,
+            delegation_contract=delegation_contract
+        )
+
+        assert transaction.sender == "erd18s6a06ktr2v6fgxv4ffhauxvptssnaqlds45qgsrucemlwc8rawq553rt2"
+        assert transaction.receiver == "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqtllllls002zgc"
+        assert transaction.data
+        assert transaction.data.decode() == "withdraw"
+        assert transaction.amount == 0
+        assert transaction.gas_limit == 12000000

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "multiversx-sdk-core"
-version = "0.7.2"
+version = "0.7.3"
 authors = [
   { name="MultiversX" },
 ]


### PR DESCRIPTION
There were some missing delegation operations such as: delegate to a delegation contract, claim rewards, redelegate rewards, undelegate and withdraw.