### PR TITLE
Fix flags when creating token management transactions

### DIFF
--- a/multiversx_sdk_core/transaction_factories/token_management_transactions_factory.py
+++ b/multiversx_sdk_core/transaction_factories/token_management_transactions_factory.py
@@ -4,7 +4,7 @@ from enum import Enum
 from typing import List, Protocol
 
 from multiversx_sdk_core.interfaces import IAddress
-from multiversx_sdk_core.serializer import arg_to_string, args_to_strings
+from multiversx_sdk_core.serializer import arg_to_string
 from multiversx_sdk_core.transaction import Transaction
 from multiversx_sdk_core.transaction_factories.transaction_builder import \
     TransactionBuilder
@@ -44,6 +44,7 @@ class TokenManagementTransactionsFactory:
     def __init__(self, config: IConfig):
         self._config = config
         self._true_as_hex = arg_to_string("true")
+        self._false_as_hex = arg_to_string("false")
 
     def create_transaction_for_issuing_fungible(
         self,
@@ -67,12 +68,12 @@ class TokenManagementTransactionsFactory:
             arg_to_string(token_ticker),
             arg_to_string(initial_supply),
             arg_to_string(num_decimals),
-            *([arg_to_string("canFreeze"), self._true_as_hex] if can_freeze else []),
-            *([arg_to_string("canWipe"), self._true_as_hex] if can_wipe else []),
-            *([arg_to_string("canPause"), self._true_as_hex] if can_pause else []),
-            *([arg_to_string("canChangeOwner"), self._true_as_hex] if can_change_owner else []),
-            *(args_to_strings(["canUpgrade", str(can_upgrade).lower()])),
-            *(args_to_strings(["canAddSpecialRoles", str(can_add_special_roles).lower()]))
+            *([arg_to_string("canFreeze"), self._true_as_hex if can_freeze else self._false_as_hex]),
+            *([arg_to_string("canWipe"), self._true_as_hex if can_wipe else self._false_as_hex]),
+            *([arg_to_string("canPause"), self._true_as_hex if can_pause else self._false_as_hex]),
+            *([arg_to_string("canChangeOwner"), self._true_as_hex if can_change_owner else self._false_as_hex]),
+            *([arg_to_string("canUpgrade"), self._true_as_hex if can_upgrade else self._false_as_hex]),
+            *([arg_to_string("canAddSpecialRoles"), self._true_as_hex if can_add_special_roles else self._false_as_hex])
         ]
 
         return TransactionBuilder(
@@ -112,13 +113,13 @@ Once the token is registered, you can unset this role by calling "unsetBurnRoleG
             "issueSemiFungible",
             arg_to_string(token_name),
             arg_to_string(token_ticker),
-            *([arg_to_string("canFreeze"), self._true_as_hex] if can_freeze else []),
-            *([arg_to_string("canWipe"), self._true_as_hex] if can_wipe else []),
-            *([arg_to_string("canPause"), self._true_as_hex] if can_pause else []),
-            *([arg_to_string("canTransferNFTCreateRole"), self._true_as_hex] if can_transfer_nft_create_role else []),
-            *([arg_to_string("canChangeOwner"), self._true_as_hex] if can_change_owner else []),
-            *(args_to_strings(["canUpgrade", str(can_upgrade).lower()])),
-            *(args_to_strings(["canAddSpecialRoles", str(can_add_special_roles).lower()]))
+            *([arg_to_string("canFreeze"), self._true_as_hex if can_freeze else self._false_as_hex]),
+            *([arg_to_string("canWipe"), self._true_as_hex if can_wipe else self._false_as_hex]),
+            *([arg_to_string("canPause"), self._true_as_hex if can_pause else self._false_as_hex]),
+            *([arg_to_string("canTransferNFTCreateRole"), self._true_as_hex if can_transfer_nft_create_role else self._false_as_hex]),
+            *([arg_to_string("canChangeOwner"), self._true_as_hex if can_change_owner else self._false_as_hex]),
+            *([arg_to_string("canUpgrade"), self._true_as_hex if can_upgrade else self._false_as_hex]),
+            *([arg_to_string("canAddSpecialRoles"), self._true_as_hex if can_add_special_roles else self._false_as_hex])
         ]
 
         return TransactionBuilder(
@@ -150,13 +151,13 @@ Once the token is registered, you can unset this role by calling "unsetBurnRoleG
             "issueNonFungible",
             arg_to_string(token_name),
             arg_to_string(token_ticker),
-            *([arg_to_string("canFreeze"), self._true_as_hex] if can_freeze else []),
-            *([arg_to_string("canWipe"), self._true_as_hex] if can_wipe else []),
-            *([arg_to_string("canPause"), self._true_as_hex] if can_pause else []),
-            *([arg_to_string("canTransferNFTCreateRole"), self._true_as_hex] if can_transfer_nft_create_role else []),
-            *([arg_to_string("canChangeOwner"), self._true_as_hex] if can_change_owner else []),
-            *(args_to_strings(["canUpgrade", str(can_upgrade).lower()])),
-            *(args_to_strings(["canAddSpecialRoles", str(can_add_special_roles).lower()]))
+            *([arg_to_string("canFreeze"), self._true_as_hex if can_freeze else self._false_as_hex]),
+            *([arg_to_string("canWipe"), self._true_as_hex if can_wipe else self._false_as_hex]),
+            *([arg_to_string("canPause"), self._true_as_hex if can_pause else self._false_as_hex]),
+            *([arg_to_string("canTransferNFTCreateRole"), self._true_as_hex if can_transfer_nft_create_role else self._false_as_hex]),
+            *([arg_to_string("canChangeOwner"), self._true_as_hex if can_change_owner else self._false_as_hex]),
+            *([arg_to_string("canUpgrade"), self._true_as_hex if can_upgrade else self._false_as_hex]),
+            *([arg_to_string("canAddSpecialRoles"), self._true_as_hex if can_add_special_roles else self._false_as_hex])
         ]
 
         return TransactionBuilder(
@@ -190,13 +191,13 @@ Once the token is registered, you can unset this role by calling "unsetBurnRoleG
             arg_to_string(token_name),
             arg_to_string(token_ticker),
             arg_to_string(num_decimals),
-            *([arg_to_string("canFreeze"), self._true_as_hex] if can_freeze else []),
-            *([arg_to_string("canWipe"), self._true_as_hex] if can_wipe else []),
-            *([arg_to_string("canPause"), self._true_as_hex] if can_pause else []),
-            *([arg_to_string("canTransferNFTCreateRole"), self._true_as_hex] if can_transfer_nft_create_role else []),
-            *([arg_to_string("canChangeOwner"), self._true_as_hex] if can_change_owner else []),
-            *([arg_to_string("canUpgrade"), self._true_as_hex] if can_upgrade else []),
-            *([arg_to_string("canAddSpecialRoles"), self._true_as_hex] if can_add_special_roles else []),
+            *([arg_to_string("canFreeze"), self._true_as_hex if can_freeze else self._false_as_hex]),
+            *([arg_to_string("canWipe"), self._true_as_hex if can_wipe else self._false_as_hex]),
+            *([arg_to_string("canPause"), self._true_as_hex if can_pause else self._false_as_hex]),
+            *([arg_to_string("canTransferNFTCreateRole"), self._true_as_hex if can_transfer_nft_create_role else self._false_as_hex]),
+            *([arg_to_string("canChangeOwner"), self._true_as_hex if can_change_owner else self._false_as_hex]),
+            *([arg_to_string("canUpgrade"), self._true_as_hex if can_upgrade else self._false_as_hex]),
+            *([arg_to_string("canAddSpecialRoles"), self._true_as_hex if can_add_special_roles else self._false_as_hex])
         ]
 
         return TransactionBuilder(

--- a/multiversx_sdk_core/transaction_factories/token_management_transactions_factory_test.py
+++ b/multiversx_sdk_core/transaction_factories/token_management_transactions_factory_test.py
@@ -37,12 +37,12 @@ def test_create_transaction_for_issuing_fungible():
         can_wipe=True,
         can_pause=True,
         can_change_owner=True,
-        can_upgrade=True,
-        can_add_special_roles=True
+        can_upgrade=False,
+        can_add_special_roles=False
     )
 
     assert transaction.data
-    assert transaction.data.decode() == "issue@4652414e4b@4652414e4b@64@@63616e467265657a65@74727565@63616e57697065@74727565@63616e5061757365@74727565@63616e4368616e67654f776e6572@74727565@63616e55706772616465@74727565@63616e4164645370656369616c526f6c6573@74727565"
+    assert transaction.data.decode() == "issue@4652414e4b@4652414e4b@64@@63616e467265657a65@74727565@63616e57697065@74727565@63616e5061757365@74727565@63616e4368616e67654f776e6572@74727565@63616e55706772616465@66616c7365@63616e4164645370656369616c526f6c6573@66616c7365"
     assert transaction.sender == frank.to_bech32()
     assert transaction.receiver == "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u"
     assert transaction.amount == 50000000000000000
@@ -58,12 +58,12 @@ def test_create_transaction_for_issuing_semi_fungible():
         can_pause=True,
         can_transfer_nft_create_role=True,
         can_change_owner=True,
-        can_upgrade=True,
-        can_add_special_roles=True
+        can_upgrade=False,
+        can_add_special_roles=False
     )
 
     assert transaction.data
-    assert transaction.data.decode() == "issueSemiFungible@4652414e4b@4652414e4b@63616e467265657a65@74727565@63616e57697065@74727565@63616e5061757365@74727565@63616e5472616e736665724e4654437265617465526f6c65@74727565@63616e4368616e67654f776e6572@74727565@63616e55706772616465@74727565@63616e4164645370656369616c526f6c6573@74727565"
+    assert transaction.data.decode() == "issueSemiFungible@4652414e4b@4652414e4b@63616e467265657a65@74727565@63616e57697065@74727565@63616e5061757365@74727565@63616e5472616e736665724e4654437265617465526f6c65@74727565@63616e4368616e67654f776e6572@74727565@63616e55706772616465@66616c7365@63616e4164645370656369616c526f6c6573@66616c7365"
     assert transaction.sender == frank.to_bech32()
     assert transaction.receiver == "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u"
     assert transaction.amount == 50000000000000000
@@ -79,12 +79,12 @@ def test_create_transaction_for_issuing_non_fungible():
         can_pause=True,
         can_transfer_nft_create_role=True,
         can_change_owner=True,
-        can_upgrade=True,
-        can_add_special_roles=True
+        can_upgrade=False,
+        can_add_special_roles=False
     )
 
     assert transaction.data
-    assert transaction.data.decode() == "issueNonFungible@4652414e4b@4652414e4b@63616e467265657a65@74727565@63616e57697065@74727565@63616e5061757365@74727565@63616e5472616e736665724e4654437265617465526f6c65@74727565@63616e4368616e67654f776e6572@74727565@63616e55706772616465@74727565@63616e4164645370656369616c526f6c6573@74727565"
+    assert transaction.data.decode() == "issueNonFungible@4652414e4b@4652414e4b@63616e467265657a65@74727565@63616e57697065@74727565@63616e5061757365@74727565@63616e5472616e736665724e4654437265617465526f6c65@74727565@63616e4368616e67654f776e6572@74727565@63616e55706772616465@66616c7365@63616e4164645370656369616c526f6c6573@66616c7365"
     assert transaction.sender == frank.to_bech32()
     assert transaction.receiver == "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u"
     assert transaction.amount == 50000000000000000
@@ -101,12 +101,12 @@ def test_create_transaction_for_registering_meta_esdt():
         can_pause=True,
         can_transfer_nft_create_role=True,
         can_change_owner=True,
-        can_upgrade=True,
-        can_add_special_roles=True
+        can_upgrade=False,
+        can_add_special_roles=False
     )
 
     assert transaction.data
-    assert transaction.data.decode() == "registerMetaESDT@4652414e4b@4652414e4b@0a@63616e467265657a65@74727565@63616e57697065@74727565@63616e5061757365@74727565@63616e5472616e736665724e4654437265617465526f6c65@74727565@63616e4368616e67654f776e6572@74727565@63616e55706772616465@74727565@63616e4164645370656369616c526f6c6573@74727565"
+    assert transaction.data.decode() == "registerMetaESDT@4652414e4b@4652414e4b@0a@63616e467265657a65@74727565@63616e57697065@74727565@63616e5061757365@74727565@63616e5472616e736665724e4654437265617465526f6c65@74727565@63616e4368616e67654f776e6572@74727565@63616e55706772616465@66616c7365@63616e4164645370656369616c526f6c6573@66616c7365"
     assert transaction.sender == frank.to_bech32()
     assert transaction.receiver == "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u"
     assert transaction.amount == 50000000000000000

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "multiversx-sdk-core"
-version = "0.7.3"
+version = "0.7.4"
 authors = [
   { name="MultiversX" },
 ]


### PR DESCRIPTION
For transactions that issue (register) tokens, all flags are now explicitly provided (whether they are SET or UNSET), in order to overcome issues related to default values (as handled by the Protocol).

A small amount of extra gasLimit is needed (to account for the slightly larger transaction.data field).