### PR TITLE
Relayed transactions factory

### DIFF
--- a/multiversx_sdk_core/errors.py
+++ b/multiversx_sdk_core/errors.py
@@ -49,3 +49,8 @@ class BadUsageError(Exception):
 class InvalidTokenIdentifierError(Exception):
     def __init__(self, message: str) -> None:
         super().__init__(message)
+
+
+class InvalidInnerTransactionError(Exception):
+    def __init__(self, message: str) -> None:
+        super().__init__(message)

--- a/multiversx_sdk_core/transaction_factories/delegation_transactions_factory_test.py
+++ b/multiversx_sdk_core/transaction_factories/delegation_transactions_factory_test.py
@@ -8,7 +8,7 @@ from multiversx_sdk_core.transaction_factories.transactions_factory_config impor
     TransactionsFactoryConfig
 
 
-class TestDelegationTransactionFactory:
+class TestDelegationTransactionsFactory:
     config = TransactionsFactoryConfig("D")
     factory = DelegationTransactionsFactory(config)
 

--- a/multiversx_sdk_core/transaction_factories/relayed_transactions_factory.py
+++ b/multiversx_sdk_core/transaction_factories/relayed_transactions_factory.py
@@ -46,7 +46,7 @@ class RelayedTransactionsFactory:
                                       inner_transaction_gas_limit: int,
                                       relayer_address: IAddress) -> Transaction:
         if inner_transaction.gas_limit:
-            raise InvalidInnerTransactionError("The gas limit should not be set for inner transaction")
+            raise InvalidInnerTransactionError("The gas limit should not be set for the inner transaction")
 
         if not inner_transaction.signature:
             raise InvalidInnerTransactionError("The inner transaction is not signed")

--- a/multiversx_sdk_core/transaction_factories/relayed_transactions_factory.py
+++ b/multiversx_sdk_core/transaction_factories/relayed_transactions_factory.py
@@ -23,7 +23,7 @@ class RelayedTransactionsFactory:
                                       inner_transaction: ITransaction,
                                       relayer_address: IAddress) -> Transaction:
         if not inner_transaction.gas_limit:
-            raise InvalidInnerTransactionError("The gas limit is not set for inner transaction")
+            raise InvalidInnerTransactionError("The gas limit is not set for the inner transaction")
 
         if not inner_transaction.signature:
             raise InvalidInnerTransactionError("The inner transaction is not signed")

--- a/multiversx_sdk_core/transaction_factories/relayed_transactions_factory.py
+++ b/multiversx_sdk_core/transaction_factories/relayed_transactions_factory.py
@@ -67,7 +67,9 @@ class RelayedTransactionsFactory:
             amount=0,
             gas_limit=gas_limit,
             chain_id=self._config.chain_id,
-            data=data.encode()
+            data=data.encode(),
+            version=inner_transaction.version,
+            options=inner_transaction.options
         )
 
     def _prepare_inner_transaction_for_relayed_v1(self, inner_transaction: ITransaction) -> str:

--- a/multiversx_sdk_core/transaction_factories/relayed_transactions_factory.py
+++ b/multiversx_sdk_core/transaction_factories/relayed_transactions_factory.py
@@ -1,0 +1,82 @@
+import base64
+import json
+from typing import Any, Dict, Protocol
+
+from multiversx_sdk_core import Address
+from multiversx_sdk_core.errors import InvalidInnerTransactionError
+from multiversx_sdk_core.interfaces import IAddress, ITransaction
+from multiversx_sdk_core.transaction import Transaction
+
+
+class IConfig(Protocol):
+    chain_id: str
+    min_gas_limit: int
+    gas_limit_per_byte: int
+
+
+class RelayedTransactionsFactory:
+    def __init__(self, config: IConfig) -> None:
+        self._config = config
+
+    def create_relayed_v1_transaction(self,
+                                      inner_transaction: ITransaction,
+                                      relayer_address: IAddress) -> Transaction:
+        if not inner_transaction.signature:
+            raise InvalidInnerTransactionError("The inner transaction is not signed")
+
+        if not inner_transaction.gas_limit:
+            raise InvalidInnerTransactionError("The gas limit is not set for inner transaction")
+
+        serialized_transaction = self._prepare_inner_transaction_for_relayed_v1(inner_transaction)
+        data = f"relayedTx@{serialized_transaction.encode().hex()}"
+
+        gas_limit = self._config.min_gas_limit + self._config.gas_limit_per_byte * len(data) + inner_transaction.gas_limit
+
+        return Transaction(
+            chain_id=self._config.chain_id,
+            sender=relayer_address.to_bech32(),
+            receiver=inner_transaction.sender,
+            gas_limit=gas_limit,
+            data=data.encode()
+        )
+
+    def _prepare_inner_transaction_for_relayed_v1(self, inner_transaction: ITransaction) -> str:
+        sender = Address.new_from_bech32(inner_transaction.sender).to_hex()
+        receiver = Address.new_from_bech32(inner_transaction.receiver).to_hex()
+
+        tx: Dict[str, Any] = {
+            "nonce": inner_transaction.nonce,
+            "sender": base64.b64encode(bytes.fromhex(sender)).decode(),
+            "receiver": base64.b64encode(bytes.fromhex(receiver)).decode(),
+            "value": inner_transaction.amount,
+            "gasPrice": inner_transaction.gas_price,
+            "gasLimit": inner_transaction.gas_limit,
+            "data": base64.b64encode(inner_transaction.data).decode(),
+            "signature": base64.b64encode(inner_transaction.signature).decode(),
+            "chainID": base64.b64encode(inner_transaction.chain_id.encode()).decode(),
+            "version": inner_transaction.version,
+        }
+
+        if inner_transaction.options:
+            tx["options"] = inner_transaction.options
+
+        if inner_transaction.guardian:
+            guardian = Address.new_from_bech32(inner_transaction.guardian).to_hex()
+            tx["guardian"] = base64.b64encode(bytes.fromhex(guardian)).decode()
+
+        if inner_transaction.guardian_signature:
+            tx["guardianSignature"] = base64.b64encode(inner_transaction.guardian_signature).decode()
+
+        if inner_transaction.sender_username:
+            tx["sndUserName"] = base64.b64encode(inner_transaction.sender_username.encode()).decode()
+
+        if inner_transaction.receiver_username:
+            tx[f"rcvUserName"] = base64.b64encode(inner_transaction.receiver_username.encode()).decode()
+
+        return json.dumps(tx, separators=(",", ":"))
+
+    def create_relayed_v2_transaction(self,
+                                      inner_transaction: ITransaction,
+                                      inner_transaction_gas_limit: int,
+                                      relayer_address: IAddress) -> Transaction:
+        pass

--- a/multiversx_sdk_core/transaction_factories/relayed_transactions_factory.py
+++ b/multiversx_sdk_core/transaction_factories/relayed_transactions_factory.py
@@ -22,11 +22,11 @@ class RelayedTransactionsFactory:
     def create_relayed_v1_transaction(self,
                                       inner_transaction: ITransaction,
                                       relayer_address: IAddress) -> Transaction:
-        if not inner_transaction.signature:
-            raise InvalidInnerTransactionError("The inner transaction is not signed")
-
         if not inner_transaction.gas_limit:
             raise InvalidInnerTransactionError("The gas limit is not set for inner transaction")
+
+        if not inner_transaction.signature:
+            raise InvalidInnerTransactionError("The inner transaction is not signed")
 
         serialized_transaction = self._prepare_inner_transaction_for_relayed_v1(inner_transaction)
         data = f"relayedTx@{serialized_transaction.encode().hex()}"

--- a/multiversx_sdk_core/transaction_factories/relayed_transactions_factory_test.py
+++ b/multiversx_sdk_core/transaction_factories/relayed_transactions_factory_test.py
@@ -208,7 +208,9 @@ class TestRelayedTransactionsFactory:
             gas_limit=0,
             chain_id=self.config.chain_id,
             data=b"getContractConfig",
-            nonce=15
+            nonce=15,
+            version=2,
+            options=0
         )
 
         serialized_inner_transaction = self.transaction_computer.compute_bytes_for_signing(inner_transaction)
@@ -224,4 +226,6 @@ class TestRelayedTransactionsFactory:
         serialized_relayed_transaction = self.transaction_computer.compute_bytes_for_signing(relayed_transaction)
         relayed_transaction.signature = alice.secret_key.sign(serialized_relayed_transaction)
 
+        assert relayed_transaction.version == 2
+        assert relayed_transaction.options == 0
         assert relayed_transaction.data.decode() == "relayedTxV2@000000000000000000010000000000000000000000000000000000000002ffff@0f@676574436f6e7472616374436f6e666967@fc3ed87a51ee659f937c1a1ed11c1ae677e99629fae9cc289461f033e6514d1a8cfad1144ae9c1b70f28554d196bd6ba1604240c1c1dc19c959e96c1c3b62d0c"

--- a/multiversx_sdk_core/transaction_factories/relayed_transactions_factory_test.py
+++ b/multiversx_sdk_core/transaction_factories/relayed_transactions_factory_test.py
@@ -1,0 +1,172 @@
+import pytest
+
+from multiversx_sdk_core import Address
+from multiversx_sdk_core.errors import InvalidInnerTransactionError
+from multiversx_sdk_core.testutils.wallets import load_wallets
+from multiversx_sdk_core.transaction import Transaction, TransactionComputer
+from multiversx_sdk_core.transaction_factories.relayed_transactions_factory import \
+    RelayedTransactionsFactory
+from multiversx_sdk_core.transaction_factories.transactions_factory_config import \
+    TransactionsFactoryConfig
+
+
+class TestRelayedTransactionsFactory:
+    config = TransactionsFactoryConfig("T")
+    factory = RelayedTransactionsFactory(config)
+    transaction_computer = TransactionComputer()
+    wallets = load_wallets()
+
+    def test_create_relayed_v1_with_invalid_inner_tx(self):
+        alice = self.wallets["alice"]
+
+        inner_transaction = Transaction(
+            sender=alice.label,
+            receiver="erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u",
+            gas_limit=10000000,
+            data="getContractConfig".encode(),
+            chain_id=self.config.chain_id
+        )
+
+        with pytest.raises(InvalidInnerTransactionError, match="The inner transaction is not signed"):
+            self.factory.create_relayed_v1_transaction(
+                inner_transaction=inner_transaction,
+                relayer_address=Address.from_bech32(self.wallets["bob"].label)
+            )
+
+        inner_transaction.gas_limit = 0
+        inner_transaction.signature = b"invalidsignature"
+
+        with pytest.raises(InvalidInnerTransactionError, match="The gas limit is not set for inner transaction"):
+            self.factory.create_relayed_v1_transaction(
+                inner_transaction=inner_transaction,
+                relayer_address=Address.from_bech32(self.wallets["bob"].label)
+            )
+
+    def test_create_realyed_v1_transaction(self):
+        alice = self.wallets["alice"]
+        bob = self.wallets["bob"]
+
+        inner_transaction = Transaction(
+            sender=bob.label,
+            receiver="erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u",
+            gas_limit=60000000,
+            chain_id=self.config.chain_id,
+            data=b"getContractConfig",
+            nonce=198
+        )
+
+        inner_tx_bytes = self.transaction_computer.compute_bytes_for_signing(inner_transaction)
+        inner_transaction.signature = bob.secret_key.sign(inner_tx_bytes)
+
+        relayed_transaction = self.factory.create_relayed_v1_transaction(
+            inner_transaction=inner_transaction,
+            relayer_address=Address.from_bech32(alice.label)
+        )
+        relayed_transaction.nonce = 2627
+
+        relayed_tx_bytes = self.transaction_computer.compute_bytes_for_signing(relayed_transaction)
+        relayed_transaction.signature = alice.secret_key.sign(relayed_tx_bytes)
+
+        assert relayed_transaction.data.decode() == "relayedTx@7b226e6f6e6365223a3139382c2273656e646572223a2267456e574f65576d6d413063306a6b71764d354241707a61644b46574e534f69417643575163776d4750673d222c227265636569766572223a22414141414141414141414141415141414141414141414141414141414141414141414141414141432f2f383d222c2276616c7565223a302c226761735072696365223a313030303030303030302c226761734c696d6974223a36303030303030302c2264617461223a225a3256305132397564484a68593352446232356d6157633d222c227369676e6174757265223a2272525455544858677a4273496e4f6e454b6b7869642b354e66524d486e33534948314673746f577352434c434b3258514c41614f4e704449346531476173624c5150616130566f364144516d4f2b52446b6f364a43413d3d222c22636861696e4944223a2256413d3d222c2276657273696f6e223a327d"
+        assert relayed_transaction.signature.hex() == "128e7cdc14c2b9beee2f3ff7a7fa5d1f5ef31a654a0c92e223c90ab28265fa277d306f23a06536248cf9573e828017004fb639617fade4d68a37524aafca710d"
+
+    def test_create_realyed_v1_transaction_with_usernames(self):
+        alice = self.wallets["alice"]
+        carol = self.wallets["carol"]
+        frank = self.wallets["frank"]
+
+        inner_transaction = Transaction(
+            sender=carol.label,
+            receiver=alice.label,
+            gas_limit=50000,
+            chain_id=self.config.chain_id,
+            nonce=208,
+            sender_username="carol",
+            receiver_username="alice",
+            amount=1000000000000000000
+        )
+
+        inner_tx_bytes = self.transaction_computer.compute_bytes_for_signing(inner_transaction)
+        inner_transaction.signature = carol.secret_key.sign(inner_tx_bytes)
+
+        relayed_transaction = self.factory.create_relayed_v1_transaction(
+            inner_transaction=inner_transaction,
+            relayer_address=Address.from_bech32(frank.label)
+        )
+        relayed_transaction.nonce = 715
+
+        relayed_tx_bytes = self.transaction_computer.compute_bytes_for_signing(relayed_transaction)
+        relayed_transaction.signature = frank.secret_key.sign(relayed_tx_bytes)
+
+        assert relayed_transaction.data.decode() == "relayedTx@7b226e6f6e6365223a3230382c2273656e646572223a227371455656633553486b6c45344a717864556e59573068397a536249533141586f3534786f32634969626f3d222c227265636569766572223a2241546c484c76396f686e63616d433877673970645168386b77704742356a6949496f3349484b594e6165453d222c2276616c7565223a313030303030303030303030303030303030302c226761735072696365223a313030303030303030302c226761734c696d6974223a35303030302c2264617461223a22222c227369676e6174757265223a226a33427a6469554144325963517473576c65707663664a6f75657a48573063316b735a424a4d6339573167435450512b6870636759457858326f6f367a4b5654347464314b4b6f79783841526a346e336474576c44413d3d222c22636861696e4944223a2256413d3d222c2276657273696f6e223a322c22736e64557365724e616d65223a22593246796232773d222c22726376557365724e616d65223a22595778705932553d227d"
+        assert relayed_transaction.signature.hex() == "3787d640e5a579e7977a4a1bcdd435ad11855632fa4a414a06fbf8355692d1a58d76ef0adbdd6ccd6bd3c329f36bd53c180d4873ec1a6c558e659aeb9ab92d00"
+
+    def test_compute_relayed_v1_with_guarded_inner_tx(self):
+        alice = self.wallets["alice"]
+        bob = self.wallets["bob"]
+        grace = self.wallets["grace"]
+
+        inner_transaction = Transaction(
+            sender=bob.label,
+            receiver="erd1qqqqqqqqqqqqqpgq54tsxmej537z9leghvp69hfu4f8gg5eu396q83gnnz",
+            gas_limit=60000000,
+            chain_id=self.config.chain_id,
+            data=b"getContractConfig",
+            nonce=198,
+            version=2,
+            options=2,
+            guardian=grace.label
+        )
+
+        inner_tx_bytes = self.transaction_computer.compute_bytes_for_signing(inner_transaction)
+        inner_transaction.signature = bob.secret_key.sign(inner_tx_bytes)
+        inner_transaction.guardian_signature = grace.secret_key.sign(inner_tx_bytes)
+
+        relayed_transaction = self.factory.create_relayed_v1_transaction(
+            inner_transaction=inner_transaction,
+            relayer_address=Address.from_bech32(alice.label)
+        )
+        relayed_transaction.nonce = 2627
+
+        relayed_tx_bytes = self.transaction_computer.compute_bytes_for_signing(relayed_transaction)
+        relayed_transaction.signature = alice.secret_key.sign(relayed_tx_bytes)
+
+        assert relayed_transaction.data.decode() == "relayedTx@7b226e6f6e6365223a3139382c2273656e646572223a2267456e574f65576d6d413063306a6b71764d354241707a61644b46574e534f69417643575163776d4750673d222c227265636569766572223a22414141414141414141414146414b565841323879704877692f79693741364c64504b704f68464d386958513d222c2276616c7565223a302c226761735072696365223a313030303030303030302c226761734c696d6974223a36303030303030302c2264617461223a225a3256305132397564484a68593352446232356d6157633d222c227369676e6174757265223a224b4b78324f33383655725135416b4f465258307578327933446a384853334b373038487174344668377161557669424550716c45614e746e6158706a6f2f333651476d4a456934784435457a6c6f4f677a634d4442773d3d222c22636861696e4944223a2256413d3d222c2276657273696f6e223a322c226f7074696f6e73223a322c22677561726469616e223a22486f714c61306e655733766843716f56696c70715372744c5673774939535337586d7a563868477450684d3d222c22677561726469616e5369676e6174757265223a222b5431526f4833625a792f54423177342b6a365155477258645637457577553073753948646551626453515269463953757a686d634b705463526d58595252366c534c6652394931624d7134674730436538363741513d3d227d"
+        assert relayed_transaction.signature.hex() == "39cff9d5100e290fbc7361cb6e2402261caf864257b4116f150e0c61e7869155dff8361fa5449431eb7a8ed847c01ba9b3b5ebafe5fac1a3d40c64829d827e00"
+
+    def test_guarded_relayed_v1_with_guarded_inner_tx(self):
+        alice = self.wallets["alice"]
+        bob = self.wallets["bob"]
+        grace = self.wallets["grace"]
+        frank = self.wallets["frank"]
+
+        inner_transaction = Transaction(
+            sender=bob.label,
+            receiver="erd1qqqqqqqqqqqqqpgq54tsxmej537z9leghvp69hfu4f8gg5eu396q83gnnz",
+            gas_limit=60000000,
+            chain_id=self.config.chain_id,
+            data=b"addNumber",
+            nonce=198,
+            version=2,
+            options=2,
+            guardian=grace.label
+        )
+
+        inner_tx_bytes = self.transaction_computer.compute_bytes_for_signing(inner_transaction)
+        inner_transaction.signature = bob.secret_key.sign(inner_tx_bytes)
+        inner_transaction.guardian_signature = grace.secret_key.sign(inner_tx_bytes)
+
+        relayed_transaction = self.factory.create_relayed_v1_transaction(
+            inner_transaction=inner_transaction,
+            relayer_address=Address.from_bech32(alice.label)
+        )
+        relayed_transaction.options = 2
+        relayed_transaction.nonce = 2627
+        relayed_transaction.guardian = frank.label
+
+        relayed_tx_bytes = self.transaction_computer.compute_bytes_for_signing(relayed_transaction)
+        relayed_transaction.signature = alice.secret_key.sign(relayed_tx_bytes)
+        relayed_transaction.guardian_signature = frank.secret_key.sign(relayed_tx_bytes)
+
+        assert relayed_transaction.data.decode() == "relayedTx@7b226e6f6e6365223a3139382c2273656e646572223a2267456e574f65576d6d413063306a6b71764d354241707a61644b46574e534f69417643575163776d4750673d222c227265636569766572223a22414141414141414141414146414b565841323879704877692f79693741364c64504b704f68464d386958513d222c2276616c7565223a302c226761735072696365223a313030303030303030302c226761734c696d6974223a36303030303030302c2264617461223a225957526b546e5674596d5679222c227369676e6174757265223a223469724d4b4a656d724d375174344e7635487633544c44683775654779487045564c4371674a3677652f7a662b746a4933354975573452633458543451533433475333356158386c6a533834324a38426854645043673d3d222c22636861696e4944223a2256413d3d222c2276657273696f6e223a322c226f7074696f6e73223a322c22677561726469616e223a22486f714c61306e655733766843716f56696c70715372744c5673774939535337586d7a563868477450684d3d222c22677561726469616e5369676e6174757265223a2270424754394e674a78307539624c56796b654d78786a454865374269696c37764932324a46676f32787a6e2f496e3032463769546563356b44395045324f747065386c475335412b532f4a36417762576834446744673d3d227d"
+        assert relayed_transaction.signature.hex() == "8ede1bbeed96b102344dffeac12c2592c62b7313cdeb132e8c8bf11d2b1d3bb8189d257a6dbcc99e222393d9b9ec77656c349dae97a32e68bdebd636066bf706"

--- a/multiversx_sdk_core/transaction_factories/relayed_transactions_factory_test.py
+++ b/multiversx_sdk_core/transaction_factories/relayed_transactions_factory_test.py
@@ -42,7 +42,7 @@ class TestRelayedTransactionsFactory:
                 relayer_address=Address.from_bech32(self.wallets["bob"].label)
             )
 
-    def test_create_realyed_v1_transaction(self):
+    def test_create_relayed_v1_transaction(self):
         alice = self.wallets["alice"]
         bob = self.wallets["bob"]
 
@@ -70,7 +70,7 @@ class TestRelayedTransactionsFactory:
         assert relayed_transaction.data.decode() == "relayedTx@7b226e6f6e6365223a3139382c2273656e646572223a2267456e574f65576d6d413063306a6b71764d354241707a61644b46574e534f69417643575163776d4750673d222c227265636569766572223a22414141414141414141414141415141414141414141414141414141414141414141414141414141432f2f383d222c2276616c7565223a302c226761735072696365223a313030303030303030302c226761734c696d6974223a36303030303030302c2264617461223a225a3256305132397564484a68593352446232356d6157633d222c227369676e6174757265223a2272525455544858677a4273496e4f6e454b6b7869642b354e66524d486e33534948314673746f577352434c434b3258514c41614f4e704449346531476173624c5150616130566f364144516d4f2b52446b6f364a43413d3d222c22636861696e4944223a2256413d3d222c2276657273696f6e223a327d"
         assert relayed_transaction.signature.hex() == "128e7cdc14c2b9beee2f3ff7a7fa5d1f5ef31a654a0c92e223c90ab28265fa277d306f23a06536248cf9573e828017004fb639617fade4d68a37524aafca710d"
 
-    def test_create_realyed_v1_transaction_with_usernames(self):
+    def test_create_relayed_v1_transaction_with_usernames(self):
         alice = self.wallets["alice"]
         carol = self.wallets["carol"]
         frank = self.wallets["frank"]

--- a/multiversx_sdk_core/transaction_factories/relayed_transactions_factory_test.py
+++ b/multiversx_sdk_core/transaction_factories/relayed_transactions_factory_test.py
@@ -36,7 +36,7 @@ class TestRelayedTransactionsFactory:
         inner_transaction.gas_limit = 0
         inner_transaction.signature = b"invalidsignature"
 
-        with pytest.raises(InvalidInnerTransactionError, match="The gas limit is not set for inner transaction"):
+        with pytest.raises(InvalidInnerTransactionError, match="The gas limit is not set for the inner transaction"):
             self.factory.create_relayed_v1_transaction(
                 inner_transaction=inner_transaction,
                 relayer_address=Address.from_bech32(self.wallets["bob"].label)
@@ -183,7 +183,7 @@ class TestRelayedTransactionsFactory:
             chain_id=self.config.chain_id
         )
 
-        with pytest.raises(InvalidInnerTransactionError, match="The gas limit should not be set for inner transaction"):
+        with pytest.raises(InvalidInnerTransactionError, match="The gas limit should not be set for the inner transaction"):
             self.factory.create_relayed_v2_transaction(
                 inner_transaction=inner_transaction,
                 inner_transaction_gas_limit=50000,

--- a/multiversx_sdk_core/transaction_test.py
+++ b/multiversx_sdk_core/transaction_test.py
@@ -63,11 +63,9 @@ class TestTransaction:
             receiver_username="alice",
             amount=1000000000000000000
         )
-        # needs to match the test from sdk-js-core
-        transaction.version = 1
 
         transaction.signature = self.carol.secret_key.sign(self.transaction_computer.compute_bytes_for_signing(transaction))
-        assert transaction.signature.hex() == "5966dd6b98fc5ecbcd203fa38fac7059ba5c17683099071883b0ad6697386769321d851388a99cb8b81aab625aa2d7e13621432dbd8ab334c5891cd7c7755200"
+        assert transaction.signature.hex() == "51e6cd78fb3ab4b53ff7ad6864df27cb4a56d70603332869d47a5cf6ea977c30e696103e41e8dddf2582996ad335229fdf4acb726564dbc1a0bc9e705b511f06"
 
     def test_compute_transaction_hash(self):
         transaction = Transaction(


### PR DESCRIPTION
Implemented the `RelayedTransactionsFactory` class based on the [sdk-specs](https://github.com/multiversx/mx-sdk-specs/blob/main/sdk-core/transactions-factories/relayed_transactions_factory.md).

The factory creates both `relayedV1` and `relayedV2` transactions and in the future, `relayedV3` transactions will also be supported.

Also added unit tests.